### PR TITLE
Update AppleRules.conf

### DIFF
--- a/ConfigFile/QuantumultX/Apple/AppleRules.conf
+++ b/ConfigFile/QuantumultX/Apple/AppleRules.conf
@@ -33,7 +33,6 @@ IP-CIDR,144.178.48.0/20,Apple,no-resolve
 IP-CIDR,192.35.50.0/24,Apple,no-resolve
 IP-CIDR,198.183.17.0/24,Apple,no-resolve
 IP-CIDR,205.180.175.0/24,Apple,no-resolve
-HOST-SUFFIX,apple.com,Apple
 HOST-SUFFIX,apple.co,Apple
 HOST-SUFFIX,apple.cn,Apple
 HOST-SUFFIX,apple.com.cn,Apple


### PR DESCRIPTION
DELETE "apple.com" to avoid the podcasts go direct which makes the Apple News Today unavailable